### PR TITLE
Fix the inconsistency of functin pointer

### DIFF
--- a/src/dfc_framework.h
+++ b/src/dfc_framework.h
@@ -9,7 +9,7 @@
 /*   Func Argument - to define action for matching  */
 /****************************************************/
 #define ARGUMENT_FOR_MATCH \
-                        int (*Match)(unsigned char *, uint32_t *, uint32_t)
+                        void (*Match)(unsigned char *, uint32_t *, uint32_t)
 
 #define SEARCH_ARGUMENT \
                         DFC_STRUCTURE *dfc, \


### PR DESCRIPTION
ARGUMENT_FOR_MATCH declared in DFC_Search is inconsistent with `void Print_Result(unsigned char *, uint32_t *, uint32_t);` 